### PR TITLE
fix unable to cancel multiple orders in a row due to mutated endpoint…

### DIFF
--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -118,7 +118,6 @@ class TransferFactory implements TransferFactoryInterface
         foreach ($this->urlParams as $paramValue) {
             if (isset($request[$paramValue])) {
                 $endpointUrl = str_replace(':' . $paramValue, $request[$paramValue], $this->endpointUrl);
-                $this->urlParams[$paramValue] = $request[$paramValue];
             }
         }
         return $this->urlResolver->getUrl($endpointUrl);


### PR DESCRIPTION
urlParams property was mutated after first pass, which in turn caused error error when cron is trying to cancel a second order