### PR TITLE
Add facet metadata for Algolia search filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
----
-# Facet metadata
-section: Plugins
----
-
 <!-- START_METADATA
 ---
 title: Vipps Checkout Module for Adobe Commerce / Magento
@@ -10,6 +5,7 @@ sidebar_position: 1
 description: Checkout Module for Adobe Commerce allows customers to choose Vipps, VISA or MasterCard as a payment method directly in the checkout.
 pagination_next: null
 pagination_prev: null
+section: Plugins
 ---
 END_METADATA -->
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+# Facet metadata
+section: Plugins
+---
+
 <!-- START_METADATA
 ---
 title: Vipps Checkout Module for Adobe Commerce / Magento


### PR DESCRIPTION
## Summary

This PR adds `section: Plugins` to the frontmatter of markdown files to enable faceted search filtering in the [Vipps MobilePay developer documentation](https://developer.vippsmobilepay.com).

## Changes

- Added `# Facet metadata` section to frontmatter
- Set `section: Plugins` for all documentation files

## Why this is needed

The Vipps MobilePay developer documentation uses Algolia for search. By adding these meta tags to the frontmatter, they are converted to `docsearch:section` HTML meta tags that Algolia's crawler extracts. This enables users to filter search results by section (Plugins, APIs, Knowledge Base, etc.).

## Testing

- [ ] Verify frontmatter is valid YAML
- [ ] Build the documentation site to ensure no errors
- [ ] After merge and deployment, verify meta tags appear in HTML