### PR TITLE
Migrate admonition titles to bracket syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Vipps MobilePay is the leading provider of smart payments in the Nordic region. 
 
 ## Account and pricing
 
-:::warning Checkout – important update
+:::warning[Checkout – important update]
 
 Vipps MobilePay has entered into an agreement to sell the Checkout solution to [Kustom](https://www.kustom.co/).
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -12,7 +12,7 @@ END_METADATA -->
 
 # Extra functionalities and customizations for Vipps Checkout
 
-:::warning Checkout – important update
+:::warning[Checkout – important update]
 
 Vipps MobilePay has entered into an agreement to sell the Checkout solution to [Kustom](https://www.kustom.co/).
 


### PR DESCRIPTION
## Summary

Migrate admonition titles from the old `:::type Title` syntax to the preferred `:::type[Title]` bracket syntax, ahead of the Docusaurus v4 migration.

## Test plan

- [ ] Verify admonitions render correctly with titled headings
